### PR TITLE
fix: incorrect reference in the error message of model-type-checking.

### DIFF
--- a/src/textpruner/pruners/pipeline_pruner.py
+++ b/src/textpruner/pruners/pipeline_pruner.py
@@ -40,7 +40,7 @@ TextPruner will infer the ``base_model_prefix`` so we can leave its value as ``N
         self.output_dir = self.general_config.output_dir
         base_model, model_type = infer_model_type(model, base_model_prefix)
         assert model_type in MODEL_MAP, \
-            f"Model type {self.model_type} is not supported, or not understood. Model type must be one of {list(MODEL_MAP.keys())}"
+            f"Model type {model_type} is not supported, or not understood. Model type must be one of {list(MODEL_MAP.keys())}"
         self.base_model = base_model
         self.model_type = model_type
 

--- a/src/textpruner/pruners/transformer_pruner.py
+++ b/src/textpruner/pruners/transformer_pruner.py
@@ -32,7 +32,7 @@ TextPruner will infer the ``base_model_prefix`` so we can leave its value as ``N
         self.model = model
         base_model, model_type = infer_model_type(model, base_model_prefix)
         assert model_type in MODEL_MAP, \
-            f"Model type {self.model_type} is not supported, or not understood. Model type must be one of {list(MODEL_MAP.keys())}"
+            f"Model type {model_type} is not supported, or not understood. Model type must be one of {list(MODEL_MAP.keys())}"
         self.base_model = base_model
         self.model_type = model_type
         self.model_structure = MODEL_MAP[self.model_type]['structure']

--- a/src/textpruner/pruners/vocabulary_pruner.py
+++ b/src/textpruner/pruners/vocabulary_pruner.py
@@ -35,7 +35,7 @@ TextPruner will infer the ``base_model_prefix`` so we can leave its value as ``N
         #infer model type
         base_model, model_type = infer_model_type(model, base_model_prefix)
         assert model_type in MODEL_MAP, \
-            f"Model type {self.model_type} is not supported, or not understood. Model type must be one of {list(MODEL_MAP.keys())}"
+            f"Model type {model_type} is not supported, or not understood. Model type must be one of {list(MODEL_MAP.keys())}"
         self.base_model = base_model
         self.model_type = model_type
 


### PR DESCRIPTION
Thanks for the awesome work! 

I've just made some minor changes on the error message. 
It seems that `self.model_type` is defined after the assert statement, so I replaced it with `model_type` to show the correct error message, instead of `AttributeError`.